### PR TITLE
Fix for exception

### DIFF
--- a/src/lang/ofg/ast/Java2OFG.rsc
+++ b/src/lang/ofg/ast/Java2OFG.rsc
@@ -33,7 +33,7 @@ map[str, int] insertArgs = (
 	 "insert": 0
 	, "insertAll": 0
 	, "put": 1
-	, "putAll": 1
+	, "putAll": 0
 	, "add": 0
 	, "addAll": 0
 );


### PR DESCRIPTION
void	putAll(Map<? extends K, ? extends V> m)

Only one argument, thus 0.